### PR TITLE
Optimized local

### DIFF
--- a/src/generalized_simplitigs.h
+++ b/src/generalized_simplitigs.h
@@ -103,10 +103,6 @@ void NextGeneralizedSimplitig(std::unordered_set<int64_t> &kMers, std::ostream& 
 
 /// Compute the generalized simplitigs greedily.
 /// This runs in O(n d_max ^ k), where n is the number of k-mers, but for practical uses it is fast.
-void GreedyGeneralizedSimplitigs(std::vector<int64_t> &kMers, std::ostream& of, int k, int d_max, bool complements) {
-    std::unordered_set<int64_t> remainingKMers (kMers.begin(), kMers.end());
-    // Delete kMers to save space.
-    kMers.clear();
-    kMers.resize(0);
-    while(!remainingKMers.empty()) NextGeneralizedSimplitig(remainingKMers, of,  k, d_max, complements);
+void GreedyGeneralizedSimplitigs(std::unordered_set<int64_t> &kMers, std::ostream& of, int k, int d_max, bool complements) {
+    while(!kMers.empty()) NextGeneralizedSimplitig(kMers, of,  k, d_max, complements);
 }

--- a/src/generalized_simplitigs.h
+++ b/src/generalized_simplitigs.h
@@ -89,9 +89,12 @@ void NextGeneralizedSimplitig(std::unordered_set<int64_t> &kMers, std::ostream& 
 
 /// Compute the generalized simplitigs greedily.
 /// This runs in O(n d_max ^ k), where n is the number of k-mers, but for practical uses it is fast.
-void GreedyGeneralizedSimplitigs(std::vector<KMer> kMers, std::ostream& of, int k, int d_max, bool complements) {
+void GreedyGeneralizedSimplitigs(std::vector<int64_t> &kMers, std::ostream& of, int k, int d_max, bool complements) {
     std::unordered_set<int64_t> remainingKMers;
-    for (auto &&kMer : kMers) remainingKMers.insert(KMerToNumber(kMer));
-    if (complements) for (auto &&kMer : kMers) remainingKMers.insert(ReverseComplement(KMerToNumber(kMer), k));
+    for (auto &&kMer : kMers) remainingKMers.insert(kMer);
+    if (complements) for (auto &&kMer : kMers) remainingKMers.insert(ReverseComplement(kMer, k));
+    // Delete the kMers.
+    kMers.clear();
+    kMers.resize(0);
     while(!remainingKMers.empty()) NextGeneralizedSimplitig(remainingKMers, of,  k, d_max, complements);
 }

--- a/src/generalized_simplitigs.h
+++ b/src/generalized_simplitigs.h
@@ -11,14 +11,31 @@
 #include <fstream>
 
 
+/// Determine whether the k-mer or its reverse complement is present.
+bool containsKMer(std::unordered_set<int64_t> &kMers, int64_t kMer, int k, bool complements) {
+    bool ret = kMers.count(kMer) > 0;
+    if (complements) ret |= kMers.count(ReverseComplement(kMer, k)) > 0;
+    return ret;
+}
+
+/// Remove the k-mer and its reverse complement.
+void eraseKMer(std::unordered_set<int64_t> &kMers, int64_t kMer, int k, bool complements) {
+    if (kMers.count(kMer) > 0) kMers.erase(kMer);
+    if (complements) {
+        int64_t reverseComplement = ReverseComplement(kMer, k);
+        if (kMers.count(reverseComplement) > 0) kMers.erase(reverseComplement);
+    }
+}
+
+
 /// Find the right extension to the provided last k-mer from the kMers.
 /// This extension has k-d overlap with the given simplitig.
 /// Return the extension - that is the d chars extending the simplitig - and the extending kMer.
-std::pair<int64_t, int64_t> RightExtension(int64_t last, std::unordered_set<int64_t> &kMers, int k, int d) {
+std::pair<int64_t, int64_t> RightExtension(int64_t last, std::unordered_set<int64_t> &kMers, int k, int d, bool complements) {
     // Try each of the {A, C, G, T}^d possible extensions of length d.
     for (int64_t ext = 0; ext < (1 << (d << 1)); ++ext) {
         int64_t next = BitSuffix(last, k - d) << (d << 1) | ext;
-        if (kMers.count(next) > 0) {
+        if (containsKMer(kMers, next, k, complements)) {
             return {ext, next};
         }
     }
@@ -28,11 +45,11 @@ std::pair<int64_t, int64_t> RightExtension(int64_t last, std::unordered_set<int6
 /// Find the left extension to the provided first k-mer from the kMers.
 /// This extension has k-d overlap with the given simplitig.
 /// Return the extension - that is the d chars extending the simplitig - and the extending kMer.
-std::pair<int64_t, int64_t> LeftExtension(int64_t first, std::unordered_set<int64_t> &kMers, int k, int d) {
+std::pair<int64_t, int64_t> LeftExtension(int64_t first, std::unordered_set<int64_t> &kMers, int k, int d, bool complements) {
     // Try each of the {A, C, G, T}^d possible extensions of length d.
     for (int64_t ext = 0; ext < (1 << (d << 1)); ++ext) {
         int64_t next = ext << ((k - d) << 1) | BitPrefix(first, k, k - d);
-        if (kMers.count(next) > 0) {
+        if (containsKMer(kMers, next, k, complements)) {
             return {ext, next};
         }
     }
@@ -42,40 +59,37 @@ std::pair<int64_t, int64_t> LeftExtension(int64_t first, std::unordered_set<int6
 /// Find the next generalized simplitig.
 /// Update the provided superstring and the mask.
 /// Also remove the used k-mers from kMers.
-/// If complements are true, it is expected that kMers contain both k-mer and its reverse complement.
+/// If complements are true, it is expected that kMers only contain one k-mer from a complementary pair.
 void NextGeneralizedSimplitig(std::unordered_set<int64_t> &kMers, std::ostream& of,  int k, int d_max, bool complements) {
      // Maintain the first and last k-mer in the simplitig.
     int64_t last = *kMers.begin(), first = last;
     std::list<char> simplitig {NucleotideAtIndex(first, k, 0)};
-    kMers.erase(last);
-    if (complements) kMers.erase(ReverseComplement(last, k));
+    eraseKMer(kMers, last, k, complements);
     int d_l = 1, d_r = 1;
     while (d_l <= d_max || d_r <= d_max) {
         if (d_r <= d_l) {
-            auto extension = RightExtension(last, kMers, k, d_r);
+            auto extension = RightExtension(last, kMers, k, d_r, complements);
             int64_t ext = extension.first;
             if (ext == -1) {
                 // No right extension found.
                 ++d_r;
             } else {
                 // Extend the generalized simplitig to the right.
-                kMers.erase(extension.second);
-                if (complements) kMers.erase(ReverseComplement(extension.second, k));
+                eraseKMer(kMers, extension.second, k, complements);
                 for (int i = 1; i < d_r; ++i) simplitig.emplace_back((char)std::tolower(NucleotideAtIndex(last, k, i)));
                 simplitig.emplace_back(NucleotideAtIndex(last, k, d_r));
                 last = extension.second;
                 d_r = 1;
             }
         } else {
-            auto extension = LeftExtension(first, kMers, k, d_l);
+            auto extension = LeftExtension(first, kMers, k, d_l, complements);
             int64_t ext = extension.first;
             if (ext == -1) {
                 // No left extension found.
                 ++d_l;
             } else {
                 // Extend the simplitig to the left.
-                kMers.erase(extension.second);
-                if (complements) kMers.erase(ReverseComplement(extension.second, k));
+                eraseKMer(kMers, extension.second, k, complements);
                 for (int i = d_l - 1; i > 0; --i) simplitig.emplace_front((char)std::tolower(NucleotideAtIndex(extension.second, k, i)));
                 simplitig.emplace_front(NucleotideAtIndex(extension.second, k, 0));
                 first = extension.second;
@@ -90,10 +104,8 @@ void NextGeneralizedSimplitig(std::unordered_set<int64_t> &kMers, std::ostream& 
 /// Compute the generalized simplitigs greedily.
 /// This runs in O(n d_max ^ k), where n is the number of k-mers, but for practical uses it is fast.
 void GreedyGeneralizedSimplitigs(std::vector<int64_t> &kMers, std::ostream& of, int k, int d_max, bool complements) {
-    std::unordered_set<int64_t> remainingKMers;
-    for (auto &&kMer : kMers) remainingKMers.insert(kMer);
-    if (complements) for (auto &&kMer : kMers) remainingKMers.insert(ReverseComplement(kMer, k));
-    // Delete the kMers.
+    std::unordered_set<int64_t> remainingKMers (kMers.begin(), kMers.end());
+    // Delete kMers to save space.
     kMers.clear();
     kMers.resize(0);
     while(!remainingKMers.empty()) NextGeneralizedSimplitig(remainingKMers, of,  k, d_max, complements);

--- a/src/generalized_simplitigs_unittest.h
+++ b/src/generalized_simplitigs_unittest.h
@@ -110,8 +110,9 @@ namespace {
 
         for (auto t: tests) {
             std::stringstream of;
+            auto kMerSet = std::unordered_set<int64_t> (t.kMers.begin(), t.kMers.end());
 
-            GreedyGeneralizedSimplitigs(t.kMers, of, t.k, t.d_max, t.complements);
+            GreedyGeneralizedSimplitigs(kMerSet, of, t.k, t.d_max, t.complements);
 
             EXPECT_EQ(t.wantSuperstring, of.str());
         }

--- a/src/generalized_simplitigs_unittest.h
+++ b/src/generalized_simplitigs_unittest.h
@@ -10,20 +10,21 @@ namespace {
             std::unordered_set<int64_t> kMers;
             int k;
             int d;
+            bool complements;
             int64_t wantExt;
             int64_t  wantNext;
         };
         std::vector<TestCase> tests = {
                 // ACT; {TCC, CTA, ACT, CCT}; A; CTA
-                {0b000111, {0b110101, 0b011100, 0b000111, 0b010111}, 3, 1, 0b00, 0b011100},
+                {0b000111, {0b110101, 0b011100, 0b000111, 0b010111}, 3, 1, false, 0b00, 0b011100},
                 // ACT; {TCC, ACT, CCT}; CC; TCC
-                {0b111111, {0b110101, 0b000111, 0b010111}, 3, 2,   0b0101, 0b110101},
+                {0b111111, {0b110101, 0b000111, 0b010111}, 3, 2,   false, 0b0101, 0b110101},
                 // ACT; {TCC, ACT, CCT}
-                {0b000111, {0b110101, 0b000111, 0b010111}, 3, 1,    -1, -1},
+                {0b000111, {0b110101, 0b000111, 0b010111}, 3, 1,  false,  -1, -1},
         };
 
         for (auto t: tests) {
-            auto got = RightExtension(t.last, t.kMers, t.k, t.d);
+            auto got = RightExtension(t.last, t.kMers, t.k, t.d, t.complements);
             auto gotExt = got.first;
             auto gotNext = got.second;
             EXPECT_EQ(t.wantNext, gotNext);
@@ -37,18 +38,19 @@ namespace {
             std::unordered_set<int64_t> kMers;
             int k;
             int d;
+            bool complements;
             int64_t wantExt;
             int64_t  wantNext;
         };
         std::vector<TestCase> tests = {
                 // ACT; {TCC, ACT, CCT}
-                {0b000111, {0b110101, 0b000111, 0b010111}, 3, 1,    -1, -1},
+                {0b000111, {0b110101, 0b000111, 0b010111}, 3, 1, false,   -1, -1},
                 // TAC; {TCC, CTA, ACT, CCT}; C; CTA
-                {0b110001, {0b110101, 0b011100, 0b000111, 0b010111}, 3, 1,    0b01, 0b011100},
+                {0b110001, {0b110101, 0b011100, 0b000111, 0b010111}, 3, 1, false, 0b01, 0b011100},
         };
 
         for (auto t: tests) {
-            auto got = LeftExtension(t.first, t.kMers, t.k, t.d);
+            auto got = LeftExtension(t.first, t.kMers, t.k, t.d, t.complements);
             auto gotExt = got.first;
             auto gotNext = got.second;
             EXPECT_EQ(t.wantNext, gotNext);

--- a/src/generalized_simplitigs_unittest.h
+++ b/src/generalized_simplitigs_unittest.h
@@ -93,16 +93,16 @@ namespace {
 
     TEST(GreedyGeneralizedSimplitigsTest, GreedyGeneralizedSimplitigs) {
         struct TestCase {
-            std::vector<KMer> kMers;
+            std::vector<int64_t> kMers;
             int k;
             int d_max;
             bool complements;
             std::string wantSuperstring;
         };
         std::vector<TestCase> tests = {
-                {{KMer{"GCT"}, KMer{"TAA"}, KMer{"AAA"}}, 3, 2, false, "GcTAaa"},
-                {{KMer{"TAA"}, KMer{"AAA"}, KMer{"GCT"}}, 3, 2, false, "GcTAaa"},
-                {{KMer{"TTTCTTTTTTTTTTTTTTTTTTTTTTTTTTG"}, KMer{"TTCTTTTTTTTTTTTTTTTTTTTTTTTTTGA"}}, 31, 5, false,
+                {{KMerToNumber(KMer{"GCT"}), KMerToNumber(KMer{"TAA"}), KMerToNumber(KMer{"AAA"})}, 3, 2, false, "GcTAaa"},
+                {{KMerToNumber(KMer{"TAA"}), KMerToNumber(KMer{"AAA"}), KMerToNumber(KMer{"GCT"})}, 3, 2, false, "GcTAaa"},
+                {{KMerToNumber(KMer{"TTTCTTTTTTTTTTTTTTTTTTTTTTTTTTG"}), KMerToNumber(KMer{"TTCTTTTTTTTTTTTTTTTTTTTTTTTTTGA"})}, 31, 5, false,
                  "TTtcttttttttttttttttttttttttttga"},
         };
 

--- a/src/kmers.h
+++ b/src/kmers.h
@@ -41,15 +41,34 @@ int64_t BitSuffix(int64_t kMer, int d) {
     return kMer & ((1LL << (d << 1LL)) - 1LL);
 }
 
+/// Checkered mask. cmask<uint16_t, 1> is every other bit on
+/// (0x55). cmask<uint16_t,2> is two bits one, two bits off (0x33). Etc.
+/// Copyright: Jellyfish GPL-3.0
+template<typename U, int len, int l = sizeof(U) * 8 / (2 * len)>
+struct cmask {
+    static const U v =
+            (cmask<U, len, l - 1>::v << (2 * len)) | (((U)1 << len) - 1);
+};
+template<typename U, int len>
+struct cmask<U, len, 0> {
+    static const U v = 0;
+};
+
+/// Compute the reverse complement of a word.
+/// Copyright: Jellyfish GPL-3.0
+inline uint64_t word_reverse_complement(uint64_t w) {
+    typedef uint64_t U;
+    w = ((w >> 2)  & cmask<U, 2 >::v) | ((w & cmask<U, 2 >::v) << 2);
+    w = ((w >> 4)  & cmask<U, 4 >::v) | ((w & cmask<U, 4 >::v) << 4);
+    w = ((w >> 8)  & cmask<U, 8 >::v) | ((w & cmask<U, 8 >::v) << 8);
+    w = ((w >> 16) & cmask<U, 16>::v) | ((w & cmask<U, 16>::v) << 16);
+    w = ( w >> 32                   ) | ( w                    << 32);
+    return ((U)-1) - w;
+}
+
 /// Compute the reverse complement of the given k-mer.
 int64_t ReverseComplement(int64_t kMer, int k) {
-    int64_t ans = 0;
-    for (int i = 0; i < k; ++i) {
-        ans <<= 2;
-        ans |= 3 ^ (kMer & 3);
-        kMer >>= 2;
-    }
-    return ans;
+    return (((int64_t)word_reverse_complement(kMer)) >> (64LL - (k << 1LL))) & ((1LL << (k << 1LL)) - 1LL);
 }
 
 /// Return the complementary nucleotide for the given one.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,16 +113,18 @@ int main(int argc, char **argv) {
         WriteName(k, *of);
         Streaming(path, *of,  k , complements);
     }
-    // Handle greedy separately so that it consumes less memory.
-    else if (algorithm == "global") {
+    // Handle hash table based separately so that it consumes less memory.
+    else if (algorithm == "global" || algorithm == "local") {
         auto kMers = ReadKMers(path, k, complements);
         if (kMers.empty()) {
             std::cerr << "Path '" << path << "' contains no k-mers." << std::endl;
             Help();
             return 1;
         }
+        d_max = std::min(k - 1, d_max);
         WriteName(k, *of);
-        Greedy(kMers, *of, k, complements);
+        if (algorithm == "global") Greedy(kMers, *of, k, complements);
+        else  GreedyGeneralizedSimplitigs(kMers, *of, k, d_max, complements);
     } else {
         auto data = ReadFasta(path);
         if (data.empty()) {
@@ -136,9 +138,6 @@ int main(int argc, char **argv) {
         WriteName(k, *of);
         if (algorithm == "globalAC") {
             GreedyAC(kMers, *of, complements);
-        }
-        else if (algorithm == "local") {
-            GreedyGeneralizedSimplitigs(kMers, *of, k, d_max, complements);
         }
         else if (algorithm == "localAC") {
             GreedyGeneralizedSimplitigsAC(kMers, *of, k, d_max, complements);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,7 +123,12 @@ int main(int argc, char **argv) {
         }
         d_max = std::min(k - 1, d_max);
         WriteName(k, *of);
-        if (algorithm == "global") Greedy(kMers, *of, k, complements);
+        if (algorithm == "global") {
+            auto kMerVec = std::vector<int64_t> (kMers.begin(), kMers.end());
+            kMers.clear();
+            kMers.reserve(0);
+            Greedy(kMerVec, *of, k, complements);
+        }
         else  GreedyGeneralizedSimplitigs(kMers, *of, k, d_max, complements);
     } else {
         auto data = ReadFasta(path);

--- a/src/parser.h
+++ b/src/parser.h
@@ -116,7 +116,7 @@ void AddKMersFromSequence(std::unordered_set<int64_t> &kMers, std::string &data,
 /// Return unique k-mers in no particular order.
 /// If complements is set to true, the result contains only one of the complementary k-mers - it is not guaranteed which one.
 /// This runs in O(sequence length) expected time.
-std::vector<int64_t> ReadKMers(std::string &path, int k, bool complements) {
+std::unordered_set<int64_t> ReadKMers(std::string &path, int k, bool complements) {
     std::ifstream fasta(path);
     std::unordered_set<int64_t> kMers;
     std::string sequence;
@@ -138,5 +138,5 @@ std::vector<int64_t> ReadKMers(std::string &path, int k, bool complements) {
     } else {
         throw std::invalid_argument("couldn't open file " + path);
     }
-    return {kMers.begin(), kMers.end()};
+    return kMers;
 }


### PR DESCRIPTION
Changes:
- Local:
  - [x]  Read k-mers as integers
  - [x]  Store only a single k-mer from RC pair
  - [x]  Compute RCs efficiently using bit-tricks

Improvements (for spneumo and k=13):
- Local: 26% Memory; 56% Runtime
- Global 100% Memory; 86% Runtime
