### PR TITLE
KmerCamel can compute lower bounds on superstring lengths.

### DIFF
--- a/src/global.h
+++ b/src/global.h
@@ -57,7 +57,7 @@ void PartialPreSort(std::vector<kmer_t> &vals, int k) {
 /// If complements are provided, treat k-mer and its complement as identical.
 /// If this is the case, k-mers are expected to contain only one k-mer from a complement pair.
 /// Moreover, if so, the resulting Hamiltonian path contains two superstrings which are reverse complements of one another.
-overlapPath OverlapHamiltonianPath (std::vector<kmer_t> &kMers, int k, bool complements) {
+overlapPath OverlapHamiltonianPath (std::vector<kmer_t> &kMers, int k, bool complements, bool lower_bound = false) {
     size_t n = kMers.size();
     size_t kMersCount = n * (1 + complements);
     size_t batchSize = kMersCount / MEMORY_REDUCTION_FACTOR + 1;
@@ -106,10 +106,12 @@ overlapPath OverlapHamiltonianPath (std::vector<kmer_t> &kMers, int k, bool comp
                     if (suffix_key == kh_end(prefixes)) continue;
                     size_t previous, j;
                     previous = j = kh_val(prefixes, suffix_key);
-                    // If the path forms a cycle, or is between k-mer and its reverse complement, or the k-mers complement was already selected skip this path.
                     while (j != size_t(-1) && \
-                           (accessFirstLast(first, last, i, n) % n == j % n \
-                           || accessFirstLast(first, last, i, n) % n == accessFirstLast(last, first, j, n) % n \
+                            // k-mers are complementary
+                           ((i + n) % (2 * n) == j \
+                           // forms a cycle
+                           || (!lower_bound && accessFirstLast(first, last, i, n) == j) \
+                           // k-mer is already used
                            || prefixForbidden[j])) {
                         size_t new_j = next[j - from];
                         // If the k-mer is forbidden, remove it to keep the complexity linear.

--- a/src/lower_bound.h
+++ b/src/lower_bound.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "global.h"
+#include "kmers.h"
+
+/// Return the length of the cycle cover which lower bounds the superstring length.
+size_t LowerBoundLength(std::vector<kmer_t> kMers, int k, bool complements) {
+    auto cycle_cover = OverlapHamiltonianPath(kMers, k, complements, true);
+    size_t res = 0;
+    for (auto &overlap : cycle_cover.second) {
+        res += size_t(k) - size_t(overlap);
+    }
+    return res / (1 + complements);
+}

--- a/tests/global_unittest.h
+++ b/tests/global_unittest.h
@@ -78,6 +78,7 @@ namespace {
             overlapPath wantResult;
             int k;
             bool complements;
+            bool lower_bound;
         };
         std::vector<TestCase> tests = {
                 {
@@ -85,11 +86,13 @@ namespace {
                         {{(size_t)-1, (size_t)-1}, {(byte)-1, (byte)-1}},
                         2,
                         true,
+                        false,
                 },
                 {
                         {KMerToNumber({"ACG"}), KMerToNumber({"TAC"}), KMerToNumber({"GGC"})},
                         {{2, 0, (size_t)-1}, {1, 2, (byte)-1}},
                         3,
+                        false,
                         false,
                 },
                 {
@@ -97,11 +100,26 @@ namespace {
                         {{4, 3, 0, 5, (size_t)-1, (size_t)-1}, {2, 2, 3, 3, (byte)-1, (byte)-1}},
                         4,
                         true,
+                        false,
+                },
+                {
+                        {KMerToNumber({"ACG"}), KMerToNumber({"CGT"}), KMerToNumber({"TAA"})},
+                        {{1, 2, 0}, {2, 1, 1}},
+                        3,
+                        false,
+                        true,
+                },
+                {
+                        {KMerToNumber({"ACC"}), KMerToNumber({"CGG"})},
+                        {{3, 2, 1, 0}, {2, 2, 0, 0}},
+                        3,
+                        true,
+                        true,
                 },
         };
 
         for (auto t : tests) {
-            overlapPath got = OverlapHamiltonianPath( t.kMers, t.k, t.complements);
+            overlapPath got = OverlapHamiltonianPath( t.kMers, t.k, t.complements, t.lower_bound);
             EXPECT_EQ(t.wantResult.first, got.first);
             EXPECT_EQ(t.wantResult.second, got.second);
         }

--- a/tests/lower_bound_unittest.h
+++ b/tests/lower_bound_unittest.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "../src/lower_bound.h"
+
+#include "gtest/gtest.h"
+
+namespace {
+    TEST(LowerBound, LowerBoundLength) {
+        struct TestCase {
+            std::vector<kmer_t> kMers;
+            int k;
+            bool complements;
+            size_t wantResult;
+        };
+        std::vector<TestCase> tests = {
+                {
+                        {KMerToNumber({"ACG"}), KMerToNumber({"CGT"}), KMerToNumber({"TAA"})},
+                        3, false, 5
+                },
+                {
+                        {KMerToNumber({"AC"}), KMerToNumber({"GG"})},
+                        2, true, 3
+                },
+                {
+                        {KMerToNumber({"AAACCC"}), KMerToNumber({"CCCAAA"}), KMerToNumber({"TGGGGT"})},
+                        6, false, 11
+                },
+        };
+
+        for (auto &t : tests) {
+            auto gotResult = LowerBoundLength(t.kMers, t.k, t.complements);
+
+            ASSERT_EQ(t.wantResult, gotResult);
+        }
+    }
+}

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -6,6 +6,7 @@
 #include "local_ac_unittest.h"
 #include "streaming_unittest.h"
 #include "ac_automaton_unittest.h"
+#include "lower_bound_unittest.h"
 #include "masks_unittest.h"
 
 #include "gtest/gtest.h"


### PR DESCRIPTION
I accidentally merged the previous PR.