### PR TITLE
Runs bug

### DIFF
--- a/src/masks.h
+++ b/src/masks.h
@@ -164,7 +164,6 @@ void OptimizeRuns(std::string path, kh_S64_t *kMers, std::ostream &of, int k, bo
         else intervalsSet[i] = mappedSize == 0 ? false : (glp_get_col_prim(lp, intervalMapping[i] + 1) > 0.5);
     }
 
-    of << "> superstring" << std::endl;
     ReadIntervals(nullptr, kMers, intervalsForKMer, path, k, complements, of, intervalsSet);
     of << std::endl;
 }

--- a/src/parser.h
+++ b/src/parser.h
@@ -168,7 +168,9 @@ std::pair<size_t, size_t> ReadIntervals(kh_O64_t *intervals, kh_S64_t *kMers, st
                 currentInterval += interval_used;
                 interval_used = false;
             }
-            else if (c == '\n') readingHeader = false;
+            // Reprint the header.
+            if (readingHeader && !reading) of << c;
+            if (c == '\n') readingHeader = false;
             if (readingHeader) continue;
             auto data = NucleotideToInt(c);
             // Disregard white space.

--- a/src/parser.h
+++ b/src/parser.h
@@ -186,11 +186,7 @@ std::pair<size_t, size_t> ReadIntervals(kh_O64_t *intervals, kh_S64_t *kMers, st
             currentKMer |= data;
             --beforeKMerEnd;
             if (beforeKMerEnd == 0) {
-                bool represented = kh_get_S64(kMers, currentKMer) != kh_end(kMers);
-                if (!represented && complements) {
-                    auto rc = ReverseComplement(currentKMer, k);
-                    represented = kh_get_S64(kMers, rc) != kh_end(kMers);
-                }
+                bool represented = containsKMer(kMers, currentKMer, k, complements);
                 bool set = false;
                 if (represented) {
                     interval_used = true;

--- a/src/parser.h
+++ b/src/parser.h
@@ -187,6 +187,10 @@ std::pair<size_t, size_t> ReadIntervals(kh_O64_t *intervals, kh_S64_t *kMers, st
             --beforeKMerEnd;
             if (beforeKMerEnd == 0) {
                 bool represented = kh_get_S64(kMers, currentKMer) != kh_end(kMers);
+                if (!represented && complements) {
+                    auto rc = ReverseComplement(currentKMer, k);
+                    represented = kh_get_S64(kMers, rc) != kh_end(kMers);
+                }
                 bool set = false;
                 if (represented) {
                     interval_used = true;

--- a/tests/masks_unittest.h
+++ b/tests/masks_unittest.h
@@ -115,7 +115,7 @@ namespace {
 
     TEST(Mask, OptimizeRuns2) {
         std::string path = std::filesystem::current_path();
-        path += "/tests/testdata/runstest2.fa"; // ACTaGta
+        path += "/tests/testdata/runstest2.fa"; // ACtaGta
 
         struct TestCase {
             std::vector<kmer_t> kMers;

--- a/tests/masks_unittest.h
+++ b/tests/masks_unittest.h
@@ -112,5 +112,40 @@ namespace {
             EXPECT_EQ(t.wantResult, of.str());
         }
     }
+
+    TEST(Mask, OptimizeRuns2) {
+        std::string path = std::filesystem::current_path();
+        path += "/tests/testdata/runstest2.fa"; // ACTaGta
+
+        struct TestCase {
+            std::vector<kmer_t> kMers;
+            int k;
+            bool complements;
+            bool approximate;
+            std::string wantResult;
+        };
+        std::vector<TestCase> tests = {
+                {
+                        {
+                                KMerToNumber({"ACT"}),
+                                KMerToNumber({"CTA"}),
+                                KMerToNumber({"GTA"})
+                        },
+                        3, true, false,
+                        "> superstring\nACTAGta\n"
+                },
+        };
+
+        for (auto &t : tests) {
+            std::stringstream of;
+            auto kMersDict = kh_init_S64();
+            int ret;
+            for (auto &kMer : t.kMers) kh_put_S64(kMersDict, kMer, &ret);
+
+            OptimizeRuns(path, kMersDict, of, t.k, t.complements, t.approximate);
+
+            EXPECT_EQ(t.wantResult, of.str());
+        }
+    }
 #endif
 }

--- a/tests/masks_unittest.h
+++ b/tests/masks_unittest.h
@@ -67,13 +67,13 @@ namespace {
 
     TEST(Mask, OptimizeRuns) {
         std::string path = std::filesystem::current_path();
-        path += "/tests/testdata/runstest.fa";
 
         struct TestCase {
             std::vector<kmer_t> kMers;
             int k;
             bool complements;
             bool approximate;
+            std::string relativePath;
             std::string wantResult;
         };
         std::vector<TestCase> tests = {
@@ -86,6 +86,7 @@ namespace {
                             KMerToNumber({"AT"})
                         },
                         2, false, false,
+                        "/tests/testdata/runstest.fa",
                         "> superstring\nacgcgttACGtATt\n"
                 },
                 {
@@ -97,34 +98,9 @@ namespace {
                                 KMerToNumber({"AT"})
                         },
                         2, false, true,
+                        "/tests/testdata/runstest.fa",
                         "> superstring\nACgCGTtACGtATt\n"
                 },
-        };
-
-        for (auto &t : tests) {
-            std::stringstream of;
-            auto kMersDict = kh_init_S64();
-            int ret;
-            for (auto &kMer : t.kMers) kh_put_S64(kMersDict, kMer, &ret);
-
-            OptimizeRuns(path, kMersDict, of, t.k, t.complements, t.approximate);
-
-            EXPECT_EQ(t.wantResult, of.str());
-        }
-    }
-
-    TEST(Mask, OptimizeRuns2) {
-        std::string path = std::filesystem::current_path();
-        path += "/tests/testdata/runstest2.fa"; // ACtaGta
-
-        struct TestCase {
-            std::vector<kmer_t> kMers;
-            int k;
-            bool complements;
-            bool approximate;
-            std::string wantResult;
-        };
-        std::vector<TestCase> tests = {
                 {
                         {
                                 KMerToNumber({"ACT"}),
@@ -132,17 +108,19 @@ namespace {
                                 KMerToNumber({"GTA"})
                         },
                         3, true, false,
+                        "/tests/testdata/runstest2.fa",
                         "> superstring\nACTAGta\n"
                 },
         };
 
         for (auto &t : tests) {
             std::stringstream of;
+            auto totalPath = path + t.relativePath;
             auto kMersDict = kh_init_S64();
             int ret;
             for (auto &kMer : t.kMers) kh_put_S64(kMersDict, kMer, &ret);
 
-            OptimizeRuns(path, kMersDict, of, t.k, t.complements, t.approximate);
+            OptimizeRuns(totalPath, kMersDict, of, t.k, t.complements, t.approximate);
 
             EXPECT_EQ(t.wantResult, of.str());
         }

--- a/tests/testdata/runstest2.fa
+++ b/tests/testdata/runstest2.fa
@@ -1,2 +1,2 @@
 > superstring
-ACTaGta
+ACtaGta

--- a/tests/testdata/runstest2.fa
+++ b/tests/testdata/runstest2.fa
@@ -1,0 +1,2 @@
+> superstring
+ACTaGta


### PR DESCRIPTION
There seems to be a bug in handling reverse complements in optimizing the number of runs (I noticed that maximizing the number of 1s sometimes lead to *fewer* runs than optimizing the runs). Please check the suggested fix.