### PR TITLE
Minimum frequency filtering

### DIFF
--- a/src/khash_utils.h
+++ b/src/khash_utils.h
@@ -27,12 +27,16 @@
 // Use 128-bit integers for extra large k-mers to allow for larger k.
 KHASH_SET_INIT_INT256(S256)
 KHASH_MAP_INIT_INT256(P256, size_t)
+KHASH_MAP_INIT_INT256(Q256, uint8_t)
 // Use 128-bit integers for large k-mers to allow for larger k.
 KHASH_SET_INIT_INT128(S128)
 KHASH_MAP_INIT_INT128(P128, size_t)
+KHASH_MAP_INIT_INT128(Q128, uint8_t)
 // Use 64-bits integers for small k-mers for faster operations and less memory usage.
 KHASH_SET_INIT_INT64(S64)
 KHASH_MAP_INIT_INT64(P64, size_t)
+KHASH_MAP_INIT_INT64(Q64, uint8_t)
+
 
 #define INIT_KHASH_WRAPPER(type) \
     struct kmer_dict##type##_t { \
@@ -71,6 +75,15 @@ KHASH_MAP_INIT_INT64(P64, size_t)
         }                        \
         inline void kh_resize_map(kh_P##type##_t *map, khint_t size) { \
             kh_resize_P##type(map, size); \
+        }                        \
+        inline kh_Q##type##_t *kh_init_freq_map() { \
+            return kh_init_Q##type(); \
+        }                         \
+        inline khint_t kh_get_from_freq_map(kh_Q##type##_t *map, kmer##type##_t key) { \
+            return kh_get_Q##type(map, key); \
+        }                        \
+        inline khint_t kh_put_to_freq_map(kh_Q##type##_t *map, kmer##type##_t key, int *ret) { \
+            return kh_put_Q##type(map, key, ret); \
         }                        \
     };
 

--- a/src/khash_utils.h
+++ b/src/khash_utils.h
@@ -76,6 +76,9 @@ KHASH_MAP_INIT_INT64(Q64, uint8_t)
         inline void kh_resize_map(kh_P##type##_t *map, khint_t size) { \
             kh_resize_P##type(map, size); \
         }                        \
+        inline void kh_destroy_freq_map(kh_Q##type##_t *map) { \
+            kh_destroy_Q##type(map); \
+        }                        \
         inline kh_Q##type##_t *kh_init_freq_map() { \
             return kh_init_Q##type(); \
         }                         \
@@ -135,6 +138,26 @@ std::vector<kmer_t> kMersToVec(kh_S_t *kMers, [[maybe_unused]] kmer_t _) {
     }
     return res;
 }
+
+/// Construct a vector of the k-mer set in an arbitrary order.
+template <typename kmer_t, typename kh_Q_t>
+std::vector<kmer_t> kMersToVecFiltered(kh_Q_t *kMers, [[maybe_unused]] kmer_t _, uint16_t min_frequency) {
+    std::vector<kmer_t> res;
+    for (auto i = kh_begin(kMers); i != kh_end(kMers); ++i) {
+        if (!kh_exist(kMers, i) || ((uint16_t)kh_val(kMers, i)) + 1 < min_frequency) continue;
+        res.push_back(kh_key(kMers, i));
+    }
+    return res;
+}
+
+template <typename kmer_t, typename kh_S_t, typename kh_wrapper_t>
+void kMersFromVec(kh_S_t *kMers, kh_wrapper_t wrapper, std::vector<kmer_t> &kMerVec) {
+    for (kmer_t kMer : kMerVec) {
+        int ret;
+        wrapper.kh_put_to_set(kMers, kMer, &ret);
+    }
+}
+
 
 /// Add an interval with given index to the given k-mer.
 ///

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,7 +75,7 @@ int usage_subcommand(std::string subcommand) {
     std::cerr << "  -u       - treat k-mer and its reverse complement as distinct" << std::endl;
     
     if (subcommand == "compute")
-    std::cerr << "  -z INT   - minimum frequency to consider k-mer; default 1" << std::endl;
+    std::cerr << "  -z INT   - minimum frequency to represent a k-mer; default 1" << std::endl;
 
     if (subcommand == "mssep2ms") {
     std::cerr << "  -m FILE  - input file with mask" << std::endl;
@@ -125,7 +125,11 @@ int kmercamel(kh_wrapper_t wrapper, kmer_t kmer_type, std::string path, int k, i
         auto *kMers = wrapper.kh_init_set();
         size_t kmer_count;
         if (!assume_simplitigs) {
-            ReadKMers(kMers, wrapper, kmer_type, path, k, complements);
+            if (min_frequency == 1) {
+                ReadKMers(kMers, wrapper, kmer_type, path, k, complements);
+            } else {
+                ReadKMersFiltered(kMers, wrapper, kmer_type, path, k, complements, min_frequency);
+            }
 
             if (!kh_size(kMers)) {
                 std::cerr << "Path '" << path << "' contains no k-mers. Make sure that your file is a FASTA or gzipped FASTA." << std::endl;

--- a/src/streaming.h
+++ b/src/streaming.h
@@ -99,6 +99,7 @@ void StreamingFiltered(kh_wrapper_t wrapper, kmer_t kmer_type, std::string &path
         }
     }
 
+    wrapper.kh_destroy_freq_map(kMers);
     kseq_destroy(seq);
     gzclose(fp);
 }

--- a/src/streaming.h
+++ b/src/streaming.h
@@ -75,19 +75,21 @@ void StreamingFiltered(kh_wrapper_t wrapper, kmer_t kmer_type, std::string &path
             kMer |= c;
             kMer &= mask;
             auto rc = ReverseComplement(kMer, k);
-            auto canonical = std::min(kMer, rc);
-            if (i < firstIndex) continue;
+            auto canonical = complements ? std::min(kMer, rc) : kMer;
 
             auto ptr = wrapper.kh_get_from_freq_map(kMers, canonical);
             bool contained = ptr != kh_end(kMers);
             uint16_t count = 0;
-            if (contained) {
-                count = kh_val(kMers, ptr);
-                kh_value(kMers, ptr) = (uint8_t) std::min(255, count + 1);
-            } else {
-                int ret;
-                ptr = wrapper.kh_put_to_freq_map(kMers, kMer, &ret);
-                kh_value(kMers, ptr) = 0;
+            if (i >= firstIndex) {
+                if (contained) {
+                    count = kh_val(kMers, ptr);
+                    count++;
+                    kh_value(kMers, ptr) = (uint8_t)std::min((uint16_t)255, count);                
+                } else {
+                    int ret;
+                    ptr = wrapper.kh_put_to_freq_map(kMers, canonical, &ret);
+                    kh_value(kMers, ptr) = 0;
+                }
             }
 
             if (count + 1 == min_frequency) {

--- a/src/streaming.h
+++ b/src/streaming.h
@@ -48,3 +48,57 @@ void Streaming(kh_wrapper_t wrapper, kmer_t kmer_type, std::string &path, std::o
     kseq_destroy(seq);
     gzclose(fp);
 }
+
+template <typename kmer_t, typename kh_wrapper_t>
+void StreamingFiltered(kh_wrapper_t wrapper, kmer_t kmer_type, std::string &path, std::ostream &of, int k, bool complements, uint16_t min_frequency) {
+    gzFile fp = OpenFile(path);
+    kseq_t *seq = kseq_init(fp);
+
+    auto kMers = wrapper.kh_init_freq_map();
+
+    kmer_t mask = (kmer_t(1)) << (2 * k - 1);
+    mask |= mask - 1;
+
+
+    while (kseq_read(seq) >= 0) {
+        kmer_t kMer = 0;
+        size_t firstIndex = k - 1;
+        int64_t lastOne = -k;
+        for (size_t i = 0; i < seq->seq.l + k - 1; ++i) {
+            kmer_t c = 4;
+            if (i < seq->seq.l) c = nucleotideToInt[(uint8_t)seq->seq.s[i]];
+            if (c >= 4) {
+                kMer = 0;
+                firstIndex = i + k;
+            }
+            kMer <<= 2;
+            kMer |= c;
+            kMer &= mask;
+            auto rc = ReverseComplement(kMer, k);
+            auto canonical = std::min(kMer, rc);
+            if (i < firstIndex) continue;
+
+            auto ptr = wrapper.kh_get_from_freq_map(kMers, canonical);
+            bool contained = ptr != kh_end(kMers);
+            uint16_t count = 0;
+            if (contained) {
+                count = kh_val(kMers, ptr);
+                kh_value(kMers, ptr) = (uint8_t) std::min(255, count + 1);
+            } else {
+                int ret;
+                ptr = wrapper.kh_put_to_freq_map(kMers, kMer, &ret);
+                kh_value(kMers, ptr) = 0;
+            }
+
+            if (count + 1 == min_frequency) {
+                of << Masked(seq->seq.s[i - k + 1], true);
+                lastOne = i;
+            } else if ((int64_t (i)) <= lastOne + k - 1) {
+                of << Masked(seq->seq.s[i - k + 1], false);
+            }
+        }
+    }
+
+    kseq_destroy(seq);
+    gzclose(fp);
+}

--- a/tests/parser_unittest.h
+++ b/tests/parser_unittest.h
@@ -60,6 +60,33 @@ namespace {
 
             EXPECT_EQ(t.wantResultSize, kh_size(kMers));
         }
+    }
+    TEST(Parser, ReadKMersFiltered) {
+        std::string path = std::filesystem::current_path();
+        path += "/tests/testdata/test.fa";
+        struct TestCase {
+            int k;
+            bool complements;
+            uint16_t min_frequency;
+            size_t wantResultSize;
+        };
+        std::vector<TestCase> tests = {
+                {3, true, 2, 4},
+                {3, false, 2, 4},
+                {3, true, 3, 1},
+                {4, true, 2, 2},
+                {1, false, 5, 4},
+                {1, false, 6, 2},
+                {1, false, 11, 1},
+        };
+
+        for (auto &t: tests) {
+            auto kMers  = wrapper.kh_init_set();
+
+            ReadKMers(kMers, wrapper, kmer_t (0), path, t.k, t.complements, t.case_sensitive);
+
+            EXPECT_EQ(t.wantResultSize, kh_size(kMers));
+        }
 
     }
 #endif

--- a/tests/streaming_unittest.h
+++ b/tests/streaming_unittest.h
@@ -31,5 +31,36 @@ namespace {
             EXPECT_EQ(t.wantResult, of.str());
         }
     }
+    TEST(Streaming, StreamingFiltered) {
+        std::string path = std::filesystem::current_path();
+        path += "/tests/testdata/test.fa";
+        struct TestCase {
+            int k;
+            bool complements;
+            uint16_t min_frequency;
+            std::string wantResult;
+        };
+        std::vector<TestCase> tests = {
+                {3, true, 2, "ACCCGttTaa"},
+                {3, false, 2, "ACCCgtAac"},
+                {3, true, 3, "AAcg"},
+                {4, true, 2, "ACccgAacg"},
+                {1, true, 2, "CA"},
+                {1, false, 2, "CAGT"},
+                {1, false, 3, "CAGT"},
+                {1, false, 4, "CAGT"},
+                {1, false, 5, "CATG"},
+                {1, false, 6, "CA"},
+                {1, false, 11, "C"},
+        };
+
+        for (auto t : tests) {
+            std::stringstream of;
+
+            StreamingFiltered(kmer_dict64_t(), kmer64_t(0), path, of, t.k, t.complements, t.min_frequency);
+
+            EXPECT_EQ(t.wantResult, of.str());
+        }
+    }
 #endif
 }


### PR DESCRIPTION
Kmercamel enables representing only k-mers appearing at least certain amount of times (`-z` flag) in the original data