### PR TITLE
Lowerbound supports more parameters

### DIFF
--- a/src/global_sparse.h
+++ b/src/global_sparse.h
@@ -38,8 +38,10 @@ void PartialPreSort(std::vector<kmer_t> &vals, int k) {
 /// If complements are provided, treat k-mer and its complement as identical.
 /// If this is the case, k-mers are expected to contain only one k-mer from a complement pair.
 /// Moreover, if so, the resulting Hamiltonian path contains two superstrings which are reverse complements of one another.
+/// If lower_bound is set to true, return a shortest cycle cover instead.
 template <typename kmer_t, typename kh_wrapper_t>
-overlapPath OverlapHamiltonianPathSparse (kh_wrapper_t wrapper, std::vector<kmer_t> &kMers, int k, bool complements) {
+overlapPath OverlapHamiltonianPathSparse (kh_wrapper_t wrapper, std::vector<kmer_t> &kMers, int k, bool complements,
+                                         bool lower_bound = false) {
     size_t n = kMers.size();
     size_t kMersCount = n * (1 + complements);
     size_t batchSize = kMersCount / MEMORY_REDUCTION_FACTOR + 1;
@@ -91,7 +93,7 @@ overlapPath OverlapHamiltonianPathSparse (kh_wrapper_t wrapper, std::vector<kmer
                             // k-mers are complementary
                            ((i + n) % (2 * n) == j \
                            // forms a cycle
-                           || (accessFirstLast(first, last, i, n) == j) \
+                           || (!lower_bound && accessFirstLast(first, last, i, n) == j) \
                            // k-mer is already used
                            || prefixForbidden[j])) {
                         size_t new_j = next[j - from];

--- a/src/lower_bound.h
+++ b/src/lower_bound.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "global.h"
+#include "global_sparse.h"
 #include "kmers.h"
 
 /// Return the length of the cycle cover which lower bounds the superstring length.
@@ -11,6 +12,18 @@ size_t LowerBoundLength(kh_wrapper_t wrapper, kmer_t kmer_type, std::vector<simp
     for (auto &simplitig : simplitigs) {
         res += simplitig.size() / (2 - complements);
     }
+    for (auto &overlap : cycle_cover.second) {
+        res -= overlap;
+    }
+    return res / (1 + complements);
+}
+
+/// Same as LowerBoundLength for the k-mer overlap graph (as used by GlobalSparse / PartialPreSort).
+template <typename kmer_t, typename kh_wrapper_t>
+size_t LowerBoundLengthSparse(kh_wrapper_t wrapper, std::vector<kmer_t> &kMers, int k, bool complements) {
+    auto cycle_cover = OverlapHamiltonianPathSparse(wrapper, kMers, k, complements, true);
+    size_t n = kMers.size();
+    size_t res = n * k * (1 + complements);
     for (auto &overlap : cycle_cover.second) {
         res -= overlap;
     }

--- a/src/lower_bound.h
+++ b/src/lower_bound.h
@@ -8,6 +8,7 @@
 template <typename kmer_t, typename kh_wrapper_t>
 size_t LowerBoundLength(kh_wrapper_t wrapper, kmer_t kmer_type, std::vector<simplitig_t> simplitigs, int k, bool complements) {
     auto cycle_cover = OverlapHamiltonianPath(wrapper, kmer_type, simplitigs, k, complements, true);
+    WriteLog("Finished 2. part: Hamiltonian path.");
     size_t res = 0;
     for (auto &simplitig : simplitigs) {
         res += simplitig.size() / (2 - complements);
@@ -15,17 +16,22 @@ size_t LowerBoundLength(kh_wrapper_t wrapper, kmer_t kmer_type, std::vector<simp
     for (auto &overlap : cycle_cover.second) {
         res -= overlap;
     }
-    return res / (1 + complements);
+    res /= (1 + complements);
+    WriteLog("Finished 3. part: lower bound = " + std::to_string(res) + ".");
+    return res;
 }
 
 /// Same as LowerBoundLength for the k-mer overlap graph (as used by GlobalSparse / PartialPreSort).
 template <typename kmer_t, typename kh_wrapper_t>
 size_t LowerBoundLengthSparse(kh_wrapper_t wrapper, std::vector<kmer_t> &kMers, int k, bool complements) {
     auto cycle_cover = OverlapHamiltonianPathSparse(wrapper, kMers, k, complements, true);
+    WriteLog("Finished 2. part: Hamiltonian path.");
     size_t n = kMers.size();
     size_t res = n * k * (1 + complements);
     for (auto &overlap : cycle_cover.second) {
         res -= overlap;
     }
-    return res / (1 + complements);
+    res /= (1 + complements);
+    WriteLog("Finished 3. part: lower bound = " + std::to_string(res) + ".");
+    return res;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -151,10 +151,11 @@ int kmercamel(kh_wrapper_t wrapper, kmer_t kmer_type, std::string path, int k, i
                 simplitigs = simplitigs_from_fasta(path);
             }
             WriteLog("Finished 1. part: simplitigs (" + std::to_string(simplitigs.size()) + " simplitigs).");
-            if (!lower_bound && !assume_simplitigs && simplitigs.size() * SIMPLITIG_RATIO_THRESHOLD >= kmer_count) {
+            if (!assume_simplitigs && simplitigs.size() * SIMPLITIG_RATIO_THRESHOLD >= kmer_count) {
                auto kMerVec = simplitigs_to_kmer_vec(kmer_type, simplitigs, k, kmer_count);
                PartialPreSort(kMerVec, k);
-               GlobalSparse(wrapper, kMerVec, *of, maskf, k, complements);
+               if (!lower_bound) GlobalSparse(wrapper, kMerVec, *of, maskf, k, complements);
+               else std::cout << LowerBoundLengthSparse(wrapper, kMerVec, k, complements);
             }
             else if (lower_bound) std::cout << LowerBoundLength(wrapper, kmer_type, simplitigs, k, complements);
             else Global(wrapper, kmer_type, simplitigs, *of, maskf, k, complements);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,7 +65,7 @@ int usage_subcommand(std::string subcommand) {
     std::cerr << "  -M FILE  - if given, print also ms with mask maximizing ones (only with global)" << std::endl;
 
     
-    if (subcommand == "compute")
+    if (subcommand == "compute" || subcommand == "lowerbound")
     std::cerr << "  -S       - optimize for the input being correctly computed simplitigs (only with global)" << std::endl;
 
     if (subcommand == "compute")
@@ -74,7 +74,7 @@ int usage_subcommand(std::string subcommand) {
     if (subcommand == "compute" || subcommand == "maskopt" || subcommand == "lowerbound")
     std::cerr << "  -u       - treat k-mer and its reverse complement as distinct" << std::endl;
     
-    if (subcommand == "compute")
+    if (subcommand == "compute" || subcommand == "lowerbound")
     std::cerr << "  -z INT   - minimum frequency to represent a k-mer; default 1" << std::endl;
 
     if (subcommand == "mssep2ms") {
@@ -363,20 +363,29 @@ int camel_lowerbound(int argc, char **argv) {
     int k = 0;
     std::ostream *of = &std::cout;
     bool complements = true;
+    bool assume_simplitigs = false;
+    uint16_t min_frequency = 1;
     int opt;
     try {
-        while ((opt = getopt(argc, argv, "k:hux"))  != -1) {
+        while ((opt = getopt(argc, argv, "k:huxSz:"))  != -1) {
             switch(opt) {
                 case  'k':
                     k = std::stoi(optarg);
                     break;
                 case 'u':
                     complements = false;
+                    break;
                 case 'h':
                     usage_subcommand(subcommand);
                     return 0;
                 case 'x':
                     std::cerr << "Warning: The parameter -x currently has no effect due to the improvement in the underlying algorithm." <<std::endl;
+                    break;
+                case 'S':
+                    assume_simplitigs = true;
+                    break;
+                case 'z':
+                    min_frequency = std::stoi(optarg);
                     break;
                 default:
                     return usage_subcommand(subcommand);
@@ -395,13 +404,19 @@ int camel_lowerbound(int argc, char **argv) {
     } else if (k < 0) {
         std::cerr << "k must be positive." << std::endl;
         return usage_subcommand(subcommand);
+    } else if (min_frequency >= 256 || min_frequency < 1) {
+        std::cerr << "Minimum frequency '-z' must be between 1 and 255." << std::endl;
+        return usage_subcommand(subcommand);
+    } else if (min_frequency != 1 && assume_simplitigs) {
+        std::cerr << "Inputting simplitigs is not compatible with frequency filterring." << std::endl;
+        return usage_subcommand(subcommand);
     }
     if (k < 32) {
-        return kmercamel(kmer_dict64_t(), kmer64_t(0), path, k, 0, of, nullptr, complements, false, "global", true, false, 1);
+        return kmercamel(kmer_dict64_t(), kmer64_t(0), path, k, 0, of, nullptr, complements, false, "global", true, assume_simplitigs, min_frequency);
     } else if (k < 64) {
-        return kmercamel(kmer_dict128_t(), kmer128_t(0), path, k, 0, of, nullptr, complements, false, "global", true, false, 1);
+        return kmercamel(kmer_dict128_t(), kmer128_t(0), path, k, 0, of, nullptr, complements, false, "global", true, assume_simplitigs, min_frequency);
     } else {
-        return kmercamel(kmer_dict256_t(), kmer256_t(0), path, k, 0, of, nullptr, complements, false, "global", true, false, 1);
+        return kmercamel(kmer_dict256_t(), kmer256_t(0), path, k, 0, of, nullptr, complements, false, "global", true, assume_simplitigs, min_frequency);
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -152,6 +152,7 @@ int kmercamel(kh_wrapper_t wrapper, kmer_t kmer_type, std::string path, int k, i
             }
             WriteLog("Finished 1. part: simplitigs (" + std::to_string(simplitigs.size()) + " simplitigs).");
             if (!assume_simplitigs && simplitigs.size() * SIMPLITIG_RATIO_THRESHOLD >= kmer_count) {
+               WriteLog("2. part: Number of simplitigs over threshold, computing directly from k-mers.");
                auto kMerVec = simplitigs_to_kmer_vec(kmer_type, simplitigs, k, kmer_count);
                PartialPreSort(kMerVec, k);
                if (!lower_bound) GlobalSparse(wrapper, kMerVec, *of, maskf, k, complements);

--- a/tests/lower_bound_unittest.h
+++ b/tests/lower_bound_unittest.h
@@ -3,6 +3,7 @@
 #include "kmer_types.h"
 
 #include "../src/lower_bound.h"
+#include "../src/simplitigs.h"
 
 #include "gtest/gtest.h"
 
@@ -38,5 +39,15 @@ namespace {
 
             ASSERT_EQ(t.wantResult, gotResult);
         }
+    }
+
+    TEST(LowerBound, LowerBoundLengthSparseMatchesDenseForSingletonSimplitigs) {
+        std::vector<simplitig_t> simplitigs = {
+                simplitig_from_string({"ACG"}), simplitig_from_string({"CGT"}), simplitig_from_string({"TAA"})};
+        constexpr int k = 3;
+        auto kMerVec = simplitigs_to_kmer_vec(kmer_t(0), simplitigs, k, 16);
+        size_t sparse = LowerBoundLengthSparse(wrapper, kMerVec, k, false);
+        size_t dense = LowerBoundLength(wrapper, kmer_t(0), simplitigs, k, false);
+        ASSERT_EQ(dense, sparse);
     }
 }


### PR DESCRIPTION
- `-S` for computation from simplitigs
- `-z` for filtering
- flag `-u` is fixed